### PR TITLE
Adds ability to filter Ooyala videos/collections by label(s)

### DIFF
--- a/agents/ooyala/index.js
+++ b/agents/ooyala/index.js
@@ -13,8 +13,8 @@ module.exports = function (job, events) {
 	};
 
 	return Promise.join(
-			client.fetchCollections(),
-			client.fetchVideos()
+			client.fetchCollections(job.labels),
+			client.fetchVideos(job.labels)
 		)
 
 		// Once all 4 complete we have arrays for each

--- a/agents/ooyala/index.js
+++ b/agents/ooyala/index.js
@@ -11,19 +11,16 @@ module.exports = function (job, events) {
 		agent: job.agent,
 		count: 0
 	};
-
 	return Promise.join(
 			client.fetchCollections(job.labels),
 			client.fetchVideos(job.labels)
 		)
-
-		// Once all 4 complete we have arrays for each
 		.then(function (results) {
+			// Once each request completes, each will have a result array
 			var ooyalaCollections = results[0];
 			var ooyalaVideos = results[1];
 
 			events.broadcast({role: 'store', cmd: 'sync', sub: 'startSession'}, {organization: job.organization, syncJobId: syncJobId});
-
 			_.each(ooyalaVideos, function (video) {
 				video.organization = job.organization;
 				events.broadcast({role: 'store', cmd: 'sync', sub: 'upsert'}, {organization: job.organization, entity: video});

--- a/test/ooyala/agent_test.js
+++ b/test/ooyala/agent_test.js
@@ -2,13 +2,16 @@
 
 var nock = require('nock');
 var test = require('tape');
-var fs = require('fs');
-var path = require('path');
 var agent = require('../../agents/ooyala');
 var events = require('../events_helper');
 
-var mockAssets = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/videos.json')));
-mockAssets.items = mockAssets.items.concat(require('./fixtures/channels.json'));
+var EXPIRATION_AND_SIGNATURE_PATTERN = /expires=[^&]*&signature=[^&]*/g;
+var EXPIRATION_AND_SIGNATURE_PARAMS = 'expires=XXX&signature=YYY';
+var KEY_EXPIRATION_SIGNATURE_PARAMS = '&api_key=KEY&expires=XXX&signature=YYY';
+var EMPTY_ASSETS_RESPONSE = {items: []};
+
+var mockVideoAssets = require('./fixtures/videos.json');
+var mockChannelAssets = require('./fixtures/channels.json');
 var mockStreams = require('./fixtures/streams.json');
 var mockPublishingRule = require('./fixtures/publishing_rule.json');
 var mockChannel02Lineup = require('./fixtures/channel02-lineup.json');
@@ -16,16 +19,20 @@ var mockChannelSet01Lineup = require('./fixtures/channel-set01-lineup.json');
 
 var mockFilteredVideos = require('./fixtures/videos-filtered.json');
 var mockFilteredChannels = require('./fixtures/channels-filtered.json');
-var mockFilteredAssets = {
-	items: mockFilteredVideos.items.concat(mockFilteredChannels)
-};
 
 test('An Ooyala agent can fetch videos for an organization', function (t) {
 	t.plan(1);
 
 	nock('https://api.ooyala.com').get('/v2/publishing_rules/22222').times(4).query(true).reply(200, mockPublishingRule);
-	nock('https://api.ooyala.com').get('/v2/assets').twice().query(true).reply(200, mockAssets);
-	nock('https://api.ooyala.com').get('/v2/deleted_assets').twice().query(true).reply(200, mockAssets);
+	nock('https://api.ooyala.com')
+		.filteringPath(EXPIRATION_AND_SIGNATURE_PATTERN, EXPIRATION_AND_SIGNATURE_PARAMS)
+		.get('/v2/assets?include=metadata%2Clabels&where=asset_type%3D\'video\'' + KEY_EXPIRATION_SIGNATURE_PARAMS)
+		.reply(200, mockVideoAssets);
+	nock('https://api.ooyala.com')
+		.filteringPath(EXPIRATION_AND_SIGNATURE_PATTERN, EXPIRATION_AND_SIGNATURE_PARAMS)
+		.get('/v2/assets?include=metadata%2Clabels&where=asset_type%3D\'channel\'%20OR%20asset_type%3D\'channel_set\'' + KEY_EXPIRATION_SIGNATURE_PARAMS)
+		.reply(200, mockChannelAssets);
+	nock('https://api.ooyala.com').get('/v2/deleted_assets').twice().query(true).reply(200, EMPTY_ASSETS_RESPONSE);
 	nock('https://api.ooyala.com').get('/v2/assets/00000/streams').query(true).reply(200, mockStreams);
 	nock('https://api.ooyala.com').get('/v2/assets/11111/streams').query(true).reply(200, mockStreams);
 	nock('https://api.ooyala.com').get('/v2/assets/02/lineup').query(true).reply(200, mockChannel02Lineup);
@@ -49,18 +56,32 @@ test('An Ooyala agent can fetch videos for an organization', function (t) {
 test('An Ooyala agent can fetch videos for an organization filtered by labels', function (t) {
 	t.plan(1);
 
-	nock('https://api.ooyala.com').get('/v2/publishing_rules/22222').times(2).query(true).reply(200, mockPublishingRule);
 	nock('https://api.ooyala.com')
-		.filteringPath(/expires=[^&]*&signature=[^&]*/g, 'expires=XXX&signature=YYY')
-		.get('/v2/assets?include=metadata%2Clabels&where=asset_type%3D\'video\'%20AND%20labels%20INCLUDES%20\'Published\'&api_key=KEY&expires=XXX&signature=YYY')
-		.reply(200, mockFilteredAssets);
+		.get('/v2/publishing_rules/22222')
+		.times(2)
+		.query(true)
+		.reply(200, mockPublishingRule);
 	nock('https://api.ooyala.com')
-		.filteringPath(/expires=[^&]*&signature=[^&]*/g, 'expires=XXX&signature=YYY')
-		.get('/v2/assets?include=metadata%2Clabels&where=asset_type%3D\'channel\'%20OR%20asset_type%3D\'channel_set\'%20AND%20labels%20INCLUDES%20\'Published\'&api_key=KEY&expires=XXX&signature=YYY')
-		.reply(200, mockFilteredAssets);
-	nock('https://api.ooyala.com').get('/v2/deleted_assets').twice().query(true).reply(200, {items: []});
-	nock('https://api.ooyala.com').get('/v2/assets/00000/streams').query(true).reply(200, mockStreams);
-	nock('https://api.ooyala.com').get('/v2/assets/02/lineup').query(true).reply(200, mockChannel02Lineup);
+		.filteringPath(EXPIRATION_AND_SIGNATURE_PATTERN, EXPIRATION_AND_SIGNATURE_PARAMS)
+		.get('/v2/assets?include=metadata%2Clabels&where=asset_type%3D\'channel\'%20OR%20asset_type%3D\'channel_set\'%20AND%20labels%20INCLUDES%20\'Published\'' + KEY_EXPIRATION_SIGNATURE_PARAMS)
+		.reply(200, mockFilteredChannels);
+	nock('https://api.ooyala.com')
+		.filteringPath(EXPIRATION_AND_SIGNATURE_PATTERN, EXPIRATION_AND_SIGNATURE_PARAMS)
+		.get('/v2/assets?include=metadata%2Clabels&where=asset_type%3D\'video\'%20AND%20labels%20INCLUDES%20\'Published\'' + KEY_EXPIRATION_SIGNATURE_PARAMS)
+		.reply(200, mockFilteredVideos);
+	nock('https://api.ooyala.com')
+		.get('/v2/deleted_assets')
+		.twice()
+		.query(true)
+		.reply(200, EMPTY_ASSETS_RESPONSE);
+	nock('https://api.ooyala.com')
+		.get('/v2/assets/00000/streams')
+		.query(true)
+		.reply(200, mockStreams);
+	nock('https://api.ooyala.com')
+		.get('/v2/assets/02/lineup')
+		.query(true)
+		.reply(200, mockChannel02Lineup);
 
 	var syncJob = {
 		organization: 'odd-networks',

--- a/test/ooyala/agent_test.js
+++ b/test/ooyala/agent_test.js
@@ -14,6 +14,12 @@ var mockPublishingRule = require('./fixtures/publishing_rule.json');
 var mockChannel02Lineup = require('./fixtures/channel02-lineup.json');
 var mockChannelSet01Lineup = require('./fixtures/channel-set01-lineup.json');
 
+var mockFilteredVideos = require('./fixtures/videos-filtered.json');
+var mockFilteredChannels = require('./fixtures/channels-filtered.json');
+var mockFilteredAssets = {
+	items: mockFilteredVideos.items.concat(mockFilteredChannels)
+};
+
 test('An Ooyala agent can fetch videos for an organization', function (t) {
 	t.plan(1);
 
@@ -36,6 +42,38 @@ test('An Ooyala agent can fetch videos for an organization', function (t) {
 	agent(syncJob, events)
 		.then(function (results) {
 			t.equal(results.count, 4);
+		})
+		.catch(t.end);
+});
+
+test('An Ooyala agent can fetch videos for an organization filtered by labels', function (t) {
+	t.plan(1);
+
+	nock('https://api.ooyala.com').get('/v2/publishing_rules/22222').times(2).query(true).reply(200, mockPublishingRule);
+	nock('https://api.ooyala.com')
+		.filteringPath(/expires=[^&]*&signature=[^&]*/g, 'expires=XXX&signature=YYY')
+		.get('/v2/assets?include=metadata%2Clabels&where=asset_type%3D\'video\'%20AND%20labels%20INCLUDES%20\'Published\'&api_key=KEY&expires=XXX&signature=YYY')
+		.reply(200, mockFilteredAssets);
+	nock('https://api.ooyala.com')
+		.filteringPath(/expires=[^&]*&signature=[^&]*/g, 'expires=XXX&signature=YYY')
+		.get('/v2/assets?include=metadata%2Clabels&where=asset_type%3D\'channel\'%20OR%20asset_type%3D\'channel_set\'%20AND%20labels%20INCLUDES%20\'Published\'&api_key=KEY&expires=XXX&signature=YYY')
+		.reply(200, mockFilteredAssets);
+	nock('https://api.ooyala.com').get('/v2/deleted_assets').twice().query(true).reply(200, {items: []});
+	nock('https://api.ooyala.com').get('/v2/assets/00000/streams').query(true).reply(200, mockStreams);
+	nock('https://api.ooyala.com').get('/v2/assets/02/lineup').query(true).reply(200, mockChannel02Lineup);
+
+	var syncJob = {
+		organization: 'odd-networks',
+		agent: 'ooyala',
+		key: 'KEY',
+		secret: 'SECRET',
+		active: true,
+		labels: ['Published']
+	};
+
+	agent(syncJob, events)
+		.then(function (results) {
+			t.equal(results.count, 2);
 		})
 		.catch(t.end);
 });

--- a/test/ooyala/fixtures/channels-filtered.json
+++ b/test/ooyala/fixtures/channels-filtered.json
@@ -25,25 +25,5 @@
     "duration": "0",
     "external_id": null,
     "preview_image_url": "http://ak.c.ooyala.com/xhdG5nMjoiKNbeAz0UrQo2_YVPcZRng8/Ut_HKthATH4eww8X5hMDoxOmdtO6xlQD"
-  },
-  {
-    "player_id": "5510596cec91409989dc258390edf182",
-    "ad_set_id": null,
-    "asset_type": "channel_set",
-    "embed_code": "channel_set1",
-    "metadata": {},
-    "description": "this is a channel set",
-    "created_at": "2011-05-20T18:37:52Z",
-    "publishing_rule_id": "22222",
-    "time_restrictions": null,
-    "updated_at": "2011-05-20T18:48:11Z",
-    "hosted_at": null,
-    "original_file_name": null,
-    "labels": [],
-    "name": "my new channel",
-    "status": "live",
-    "duration": "0",
-    "external_id": null,
-    "preview_image_url": "http://ak.c.ooyala.com/xhdG5nMjoiKNbeAz0UrQo2_YVPcZRng8/Ut_HKthATH4eww8X5hMDoxOmdtO6xlQD"
   }
 ]

--- a/test/ooyala/fixtures/channels-filtered.json
+++ b/test/ooyala/fixtures/channels-filtered.json
@@ -1,29 +1,31 @@
-[
-  {
-    "player_id": "5510596cec91409989dc258390edf182",
-    "ad_set_id": null,
-    "asset_type": "channel",
-    "embed_code": "02",
-    "metadata": {},
-    "description": "this is a channel",
-    "created_at": "2011-05-20T18:37:52Z",
-    "publishing_rule_id": "22222",
-    "time_restrictions": null,
-    "updated_at": "2011-05-20T18:48:11Z",
-    "hosted_at": null,
-    "original_file_name": null,
-    "labels": [
-      {
-        "name": "Published",
-        "id": "3fcf578d80344f27b009e7f7250e9f17",
-        "parent_id": null,
-        "full_name": "/Published"
-      }
-    ],
-    "name": "my new channel",
-    "status": "live",
-    "duration": "0",
-    "external_id": null,
-    "preview_image_url": "http://ak.c.ooyala.com/xhdG5nMjoiKNbeAz0UrQo2_YVPcZRng8/Ut_HKthATH4eww8X5hMDoxOmdtO6xlQD"
-  }
-]
+{
+  "items": [
+    {
+      "player_id": "5510596cec91409989dc258390edf182",
+      "ad_set_id": null,
+      "asset_type": "channel",
+      "embed_code": "02",
+      "metadata": {},
+      "description": "this is a channel",
+      "created_at": "2011-05-20T18:37:52Z",
+      "publishing_rule_id": "22222",
+      "time_restrictions": null,
+      "updated_at": "2011-05-20T18:48:11Z",
+      "hosted_at": null,
+      "original_file_name": null,
+      "labels": [
+        {
+          "name": "Published",
+          "id": "3fcf578d80344f27b009e7f7250e9f17",
+          "parent_id": null,
+          "full_name": "/Published"
+        }
+      ],
+      "name": "my new channel",
+      "status": "live",
+      "duration": "0",
+      "external_id": null,
+      "preview_image_url": "http://ak.c.ooyala.com/xhdG5nMjoiKNbeAz0UrQo2_YVPcZRng8/Ut_HKthATH4eww8X5hMDoxOmdtO6xlQD"
+    }
+  ]
+}

--- a/test/ooyala/fixtures/channels.json
+++ b/test/ooyala/fixtures/channels.json
@@ -1,49 +1,51 @@
-[
-  {
-    "player_id": "5510596cec91409989dc258390edf182",
-    "ad_set_id": null,
-    "asset_type": "channel",
-    "embed_code": "02",
-    "metadata": {},
-    "description": "this is a channel",
-    "created_at": "2011-05-20T18:37:52Z",
-    "publishing_rule_id": "22222",
-    "time_restrictions": null,
-    "updated_at": "2011-05-20T18:48:11Z",
-    "hosted_at": null,
-    "original_file_name": null,
-    "labels": [
-      {
-        "name": "Published",
-        "id": "3fcf578d80344f27b009e7f7250e9f17",
-        "parent_id": null,
-        "full_name": "/Published"
-      }
-    ],
-    "name": "my new channel",
-    "status": "live",
-    "duration": "0",
-    "external_id": null,
-    "preview_image_url": "http://ak.c.ooyala.com/xhdG5nMjoiKNbeAz0UrQo2_YVPcZRng8/Ut_HKthATH4eww8X5hMDoxOmdtO6xlQD"
-  },
-  {
-    "player_id": "5510596cec91409989dc258390edf182",
-    "ad_set_id": null,
-    "asset_type": "channel_set",
-    "embed_code": "channel_set1",
-    "metadata": {},
-    "description": "this is a channel set",
-    "created_at": "2011-05-20T18:37:52Z",
-    "publishing_rule_id": "22222",
-    "time_restrictions": null,
-    "updated_at": "2011-05-20T18:48:11Z",
-    "hosted_at": null,
-    "original_file_name": null,
-    "labels": [],
-    "name": "my new channel",
-    "status": "live",
-    "duration": "0",
-    "external_id": null,
-    "preview_image_url": "http://ak.c.ooyala.com/xhdG5nMjoiKNbeAz0UrQo2_YVPcZRng8/Ut_HKthATH4eww8X5hMDoxOmdtO6xlQD"
-  }
-]
+{
+  "items": [
+    {
+      "player_id": "5510596cec91409989dc258390edf182",
+      "ad_set_id": null,
+      "asset_type": "channel",
+      "embed_code": "02",
+      "metadata": {},
+      "description": "this is a channel",
+      "created_at": "2011-05-20T18:37:52Z",
+      "publishing_rule_id": "22222",
+      "time_restrictions": null,
+      "updated_at": "2011-05-20T18:48:11Z",
+      "hosted_at": null,
+      "original_file_name": null,
+      "labels": [
+        {
+          "name": "Published",
+          "id": "3fcf578d80344f27b009e7f7250e9f17",
+          "parent_id": null,
+          "full_name": "/Published"
+        }
+      ],
+      "name": "my new channel",
+      "status": "live",
+      "duration": "0",
+      "external_id": null,
+      "preview_image_url": "http://ak.c.ooyala.com/xhdG5nMjoiKNbeAz0UrQo2_YVPcZRng8/Ut_HKthATH4eww8X5hMDoxOmdtO6xlQD"
+    },
+    {
+      "player_id": "5510596cec91409989dc258390edf182",
+      "ad_set_id": null,
+      "asset_type": "channel_set",
+      "embed_code": "channel_set1",
+      "metadata": {},
+      "description": "this is a channel set",
+      "created_at": "2011-05-20T18:37:52Z",
+      "publishing_rule_id": "22222",
+      "time_restrictions": null,
+      "updated_at": "2011-05-20T18:48:11Z",
+      "hosted_at": null,
+      "original_file_name": null,
+      "labels": [],
+      "name": "my new channel",
+      "status": "live",
+      "duration": "0",
+      "external_id": null,
+      "preview_image_url": "http://ak.c.ooyala.com/xhdG5nMjoiKNbeAz0UrQo2_YVPcZRng8/Ut_HKthATH4eww8X5hMDoxOmdtO6xlQD"
+    }
+  ]
+}

--- a/test/ooyala/fixtures/videos-filtered.json
+++ b/test/ooyala/fixtures/videos-filtered.json
@@ -1,0 +1,31 @@
+{
+  "items": [
+    {
+      "player_id": "1eb4382d6c7f4bcfa9e1ccf3e520198b",
+      "ad_set_id": null,
+      "asset_type": "video",
+      "embed_code": "00000",
+      "description": "Video 1",
+      "created_at": "2015-08-20T16:30:17Z",
+      "publishing_rule_id": "22222",
+      "time_restrictions": null,
+      "updated_at": "2015-08-20T16:31:30Z",
+      "hosted_at": null,
+      "original_file_name": "Video 1",
+      "name": "Video 1",
+      "status": "live",
+      "duration": "30113",
+      "external_id": null,
+      "preview_image_url": "http://ak.c.ooyala.com/Y4aWY0dzp_fj1MNc9jps3ZuNQXqmgCEt/3Gduepif0T1UGY8H4xMDoxOjBzMTt2bJ",
+      "metadata": {},
+      "labels": [
+        {
+          "name": "Published",
+          "id": "3fcf578d80344f27b009e7f7250e9f17",
+          "parent_id": null,
+          "full_name": "/Published"
+        }
+      ]
+    }
+  ]
+}

--- a/test/ooyala/fixtures/videos.json
+++ b/test/ooyala/fixtures/videos.json
@@ -17,10 +17,10 @@
       "duration": "30113",
       "external_id": null,
       "preview_image_url": "http://ak.c.ooyala.com/Y4aWY0dzp_fj1MNc9jps3ZuNQXqmgCEt/3Gduepif0T1UGY8H4xMDoxOjBzMTt2bJ",
-      "metadata": {
-      },
+      "metadata": {},
       "labels": []
-    },{
+    },
+    {
       "player_id": "1eb4382d6c7f4bcfa9e1ccf3e520198b",
       "ad_set_id": null,
       "asset_type": "video",
@@ -44,18 +44,18 @@
       },
       "labels": [
         {
-         "parent_id": null,
-         "full_name": "/LABEL2",
-         "name": "LABEL2",
-         "id": "999999-label"
+          "parent_id": null,
+          "full_name": "/LABEL2",
+          "name": "LABEL2",
+          "id": "999999-label"
         },
         {
-         "parent_id": null,
-         "full_name": "/LABEL1",
-         "name": "LABEL1",
-         "id": "999998-label"
+          "parent_id": null,
+          "full_name": "/LABEL1",
+          "name": "LABEL1",
+          "id": "999998-label"
         }
       ]
-     }
+    }
   ]
 }


### PR DESCRIPTION
Closes #2 

When adding the sync job, you can now specify a label or labels to help filter Ooyala's results like so:

```
{
  organization: 'odd-networks',
  agent: 'ooyala',
  key: 'KEY',
  secret: 'SECRET',
  active: true,
  labels: ['Published', 'Oddworks']
}

// or ...

{
  organization: 'odd-networks',
  agent: 'ooyala',
  key: 'KEY',
  secret: 'SECRET',
  active: true,
  labels: 'Published'
}
```

The labels are used to construct the `where` query parameter for the Backlot API and are only used when fetching lists of videos or channels/channel_sets, not individual assets.
